### PR TITLE
Temporarily disabled Informative Miss

### DIFF
--- a/1_Welcome.py
+++ b/1_Welcome.py
@@ -2,7 +2,7 @@ import streamlit as sl
 from json import loads
 from pages.util.util import initialize_states, DEFAULT_PRESETS, load_custom_sprite_replacements_from_csv
 
-VERSION = "0.3.2.2"
+VERSION = "0.3.2.3"
 
 
 def set_stylesheet():

--- a/BeyondChaosRandomizer/BeyondChaos/randomizer.py
+++ b/BeyondChaosRandomizer/BeyondChaos/randomizer.py
@@ -6078,7 +6078,7 @@ def randomize(connection: Pipe = None, **kwargs) -> str:
         mp_color_digits(outfile_rom_buffer)
         alphabetized_lores(outfile_rom_buffer)
         description_disruption(outfile_rom_buffer)
-        informative_miss(outfile_rom_buffer)
+        # informative_miss(outfile_rom_buffer)
         manage_doom_gaze(outfile_rom_buffer)
 
         if Options_.is_flag_active('relicmyhat'):

--- a/pages/5_About.py
+++ b/pages/5_About.py
@@ -861,6 +861,19 @@ def main():
         # Populate the Changelog tab
         #
         with tabs[2].expander(
+                label='Version 0.3.2.3: Temporarily disabled Informative Miss',
+                expanded=False
+        ):
+            sl.markdown(
+                "<ul>"
+                '<li>The Informative Miss patch is causing an issue where monster counterattacks, including '
+                'phase changes, are not working properly. The patch has been disabled while we work on a '
+                'fix.</li>'
+                "</ul><br>",
+                unsafe_allow_html=True
+            )
+
+        with tabs[2].expander(
                 label='Version 0.3.2.2: Auction house bug fix.',
                 expanded=False
         ):


### PR DESCRIPTION
- The Informative Miss patch is causing an issue where monster counterattacks, including phase changes, are not working properly. The patch has been disabled while we work on a fix.