### PR TITLE
CSS Formatting modifications for better 1080p viewing

### DIFF
--- a/1_Welcome.py
+++ b/1_Welcome.py
@@ -9,9 +9,10 @@ VERSION = "0.3.3.2"
 def set_stylesheet():
     sl.markdown(
         '<style>'
-        # '   *{'
-        # '       font-family: "Arial";'
-        # '   }'
+        '   section div.block-container{'
+        '       padding-top: 3rem;'
+        '       padding-bottom: 1rem;'
+        '   }'
         '   .streamlit-expanderHeader:first-child:first-child p{'
         '       font-size: 16px;'
         '       font-weight: bold;'

--- a/1_Welcome.py
+++ b/1_Welcome.py
@@ -3,7 +3,7 @@ import os
 from json import loads
 from pages.util.util import initialize_states, DEFAULT_PRESETS, load_custom_sprite_replacements_from_csv
 
-VERSION = "0.3.3.2"
+VERSION = "0.3.3.3"
 
 
 def set_stylesheet():

--- a/pages/2_Flags.py
+++ b/pages/2_Flags.py
@@ -29,9 +29,10 @@ def set_stylesheet():
         # '   .stApp {'
         # '       background-color: white;'
         # '   }'
-        # '   *{'
-        # '       font-family: "Arial";'
-        # '   }'
+        '   section div.block-container{'
+        '       padding-top: 3rem;'
+        '       padding-bottom: 1rem;'
+        '   }'
         # Setting the expander header text style
         '   .streamlit-expanderHeader:first-child:first-child p{'
         '       font-size: 16px;'

--- a/pages/3_Customization.py
+++ b/pages/3_Customization.py
@@ -6,9 +6,10 @@ sprite_replacement_changes = []
 def set_stylesheet():
     sl.markdown(
         '<style>'
-        # '   *{'
-        # '       font-family: "Arial";'
-        # '   }'
+        '   section div.block-container{'
+        '       padding-top: 3rem;'
+        '       padding-bottom: 1rem;'
+        '   }'
         '   div[data-testid="stText"]{'
         '       font-family: "Source Sans Pro", sans-serif;'
         '   }'

--- a/pages/4_Remonsterate.py
+++ b/pages/4_Remonsterate.py
@@ -6,9 +6,10 @@ from pages.util.util import initialize_states, img_to_html
 def set_stylesheet():
     sl.markdown(
         '<style>'
-        # '   *{'
-        # '       font-family: "Arial";'
-        # '   }'
+        '   section div.block-container{'
+        '       padding-top: 3rem;'
+        '       padding-bottom: 1rem;'
+        '   }'
         '   div[data-testid="stText"]{'
         '       font-family: "Source Sans Pro", sans-serif;'
         '   }'
@@ -23,14 +24,37 @@ def set_stylesheet():
         '       border-top: 1px solid black;'
         '       overflow-x: hidden;'
         '       overflow-y: auto;'
-        '       height: 68vh;'
+        '       height: 75vh;'
         '   }'
         '   div[data-testid="column"]:nth-child(1){'
         '       border-right: 1px solid black;'
+        '       flex: 1 1 calc(25% - 1rem);'
+        '   }'
+        '   div[data-testid="column"]:nth-child(1) p{'
+        '       margin-right: 25px;'
         '   }'
         '   div[data-testid="column"]:nth-child(2){'
         '       margin-left: -16px;'
         '       padding-left: 16px;'
+        '   }'
+        '   div[data-testid="column"]:nth-child(2) div:nth-child(1) div[data-testid="stVerticalBlock"]:nth-child(1){'
+        # '       background-color: white;'
+        '       flex-direction: row;'
+        '       flex-wrap: wrap;'
+        '   }'
+        '   div[data-testid="column"]:nth-child(2) div.element-container:nth-child(3){'
+        '       width: 55% !important;'
+        '       float: left;'
+        '   }'
+        '   div[data-testid="column"]:nth-child(2) div.element-container:nth-child(3) div.stSelectbox{'
+        '       width: 100% !important;'
+        '   }'
+        '   div[data-testid="column"]:nth-child(2) div.element-container:nth-child(4){'
+        '       width: 40% !important;'
+        '       float: right;'
+        '   }'
+        '   div[data-testid="column"]:nth-child(2) div.element-container:nth-child(4) div.stSelectbox{'
+        '       width: 100% !important;'
         '   }'
         '   div[data-testid="stImage"]{'
         '       background-color: white;'
@@ -92,8 +116,7 @@ def main():
                 'Below are a list of games and sprites that are used with the Remonsterate flag. To prevent a monster '
                 'from showing up in-game, simply remove the entry from the list.<br><br>'
                 'Want to contribute additional sprites? '
-                'Join our official Discord server!'
-                    '&emsp;'
+                'Join our official Discord server!<br>'
                     '<a href="https://discord.gg/ZCHZp7qxws">'
                         '<img class="social" src=' + img_to_html("images/ico_discord.png") + '> https://discord.gg/ZCHZp7qxws'
                     '</a>'
@@ -142,8 +165,8 @@ def main():
                 key="remonsterate_sprite_display_file",
                 on_change=load_remonsterate_image
             )
-            if not "remonsterate_image" in sl.session_state.keys():
-                load_remonsterate_image()
+
+            load_remonsterate_image()
             try:
                 sl.image(
                     image=sl.session_state["remonsterate_image"]

--- a/pages/5_Generate.py
+++ b/pages/5_Generate.py
@@ -44,9 +44,10 @@ def set_stylesheet():
         '       flex-direction: column-reverse;'
         '       display: flex;'
         '   }'
-        # '   *{'
-        # '       font-family: "Arial";'
-        # '   }'
+        '   section div.block-container{'
+        '       padding-top: 3rem;'
+        '       padding-bottom: 1rem;'
+        '   }'
         '</style>',
         unsafe_allow_html=True
     )

--- a/pages/6_About.py
+++ b/pages/6_About.py
@@ -5,9 +5,10 @@ from pages.util.util import initialize_states, img_to_html
 def set_stylesheet():
     sl.markdown(
         '<style>'
-        # '   *{'
-        # '       font-family: "Arial";'
-        # '   }'
+        '   section div.block-container{'
+        '       padding-top: 3rem;'
+        '       padding-bottom: 1rem;'
+        '   }'
         '   .streamlit-expanderHeader:first-child:first-child p{'
         '       font-size: 16px;'
         '       font-weight: bold;'

--- a/pages/6_About.py
+++ b/pages/6_About.py
@@ -849,6 +849,22 @@ def main():
         # Populate the Changelog tab
         #
         with tabs[2].expander(
+                label='Version 0.3.3.3: CSS Formatting modifications for better 1080p viewing',
+                expanded=False
+        ):
+            sl.markdown(
+                "<ul>"
+                '<li>Reduced top and bottom padding app-wide</li>'
+                '<li>On the remonsterate screen: Shrunk the left column. Wxpanded the left column. '
+                'Floated the Folder and Image drop-down selectors.</li>'
+                '<li>Fixed a bug where leaving and going back to the Remonsterate screen could show the wrong sprite '
+                'being rendered because the drop-downs do not remember the selection. Maybe I\'ll give the drop-downs '
+                'memory later.</li>'
+                "</ul><br>",
+                unsafe_allow_html=True
+            )
+
+        with tabs[2].expander(
                 label='Version 0.3.3.2: Corrected remonsterate sprite file names',
                 expanded=False
         ):


### PR DESCRIPTION
- Reduced top and bottom padding app-wide
- On the remonsterate screen: Shrunk the left column. Wxpanded the left column. Floated the Folder and Image drop-down selectors.
- Fixed a bug where leaving and going back to the Remonsterate screen could show the wrong sprite being rendered because the drop-downs do not remember the selection. Maybe I'll give the drop-downs memory later.