### PR TITLE
Fixed error importing JSON settings.

### DIFF
--- a/1_Welcome.py
+++ b/1_Welcome.py
@@ -3,7 +3,7 @@ import os
 from json import loads
 from pages.util.util import initialize_states, DEFAULT_PRESETS, load_custom_sprite_replacements_from_csv
 
-VERSION = "0.3.3.4"
+VERSION = "0.3.3.5"
 
 
 def set_stylesheet():
@@ -137,7 +137,7 @@ def process_import():
                 elif key == "remonsterate_folders":
                     results = {}
                     for path in value:
-                        folder, sprite = path.split("\\")
+                        folder, sprite = path.split(os.path.sep)
                         if folder not in results.keys():
                             results[folder] = []
                         results[folder].append(os.path.splitext(sprite)[0])

--- a/pages/6_About.py
+++ b/pages/6_About.py
@@ -849,6 +849,19 @@ def main():
         # Populate the Changelog tab
         #
         with tabs[2].expander(
+                label='Version 0.3.3.5: Fixed error importing JSON settings.',
+                expanded=False
+        ):
+            sl.markdown(
+                "<ul>"
+                '<li>The JSON settings import process assumed backslashes between directories, which was '
+                'only applicable for Windows. Since Streamlit runs on an OS using forward slashes, the import '
+                'process was throwing an error.</li>'
+                "</ul><br>",
+                unsafe_allow_html=True
+            )
+
+        with tabs[2].expander(
                 label='Version 0.3.3.4: Fixed missing import for Python\'s Math Module',
                 expanded=False
         ):


### PR DESCRIPTION
- The JSON settings import process assumed backslashes between directories, which was only applicable for Windows. Since Streamlit runs on an OS using forward slashes, the import process was throwing an error.